### PR TITLE
build: make sysroot-linux contain libstdc++ and gcc stubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+sysroot/sysroot-*-x86_64/
+sysroot/sysroot-*-aarch64/
+*.tar.*

--- a/sysroot/sysroot-config.toml
+++ b/sysroot/sysroot-config.toml
@@ -17,6 +17,20 @@ packages = [
   "libc6",
   "libc6-dev",
   "linux-libc-dev",
+  # HACK: @bowyer - I dislike this is here, but for some reason rust wnats this specifically for 
+  # unwinding - hope it plays nice with libunwind :/
+  # SEE: https://github.com/rust-lang/rust/issues/65051
+  # This is also a capitulation to the fact that we use libstdc++ in the sysroot
+  # as torch wants a gcc_s as well for unwinding
+  "libgcc-7-dev",
+  "libgcc1",
+
+  # NOTE: @bowyer - This is a capitulation for pytorch and ray. While we want to use libc++, pytorch
+  # (and ray) both link to "system" libs and include libstdc++. Without this in the sysroot we
+  # cannot run torch well, and we dont want to exclude ourselves from the torch ecosystem
+  "libstdc++6",
+  # HACK: ONLY if needed, leave disabled for now
+  #"libstdc++-7-dev",
 ]
 
 deleted_patterns = [


### PR DESCRIPTION
This is a little irritating, but we need two deps that _should_
be covered by a hermetic all LLVM toolchain.

The first is `libgcc_s.so`, this is part of the GCC compiler 
runtime. In this case this is down to rustc assuming a gnu abi
mandates this library for the requirement of unwinding. This is 
a little difficult to avoid without bootstraping rustc which we
avvoid for now.

The second is `libstdc++.so`, this is the C++ standard library
expressed as part of GNU. We are right now avoiding this as its
easier from an ABI and language version standpoint to use libc++
however we want to pick up torch and ray which presently in the
prepackaged versions are compiled with dynmic linking to libstdc++